### PR TITLE
Removed redundant definition of yylloc

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Redundant defines OK in gcc9 not OK in gcc10.  Everything still works in both.  Explanation:
https://lore.kernel.org/stable/20200331192515.GA39354@ubuntu-m2-xlarge-x86/